### PR TITLE
feat: caching and optional form

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -91,7 +91,6 @@ export async function loginAction(
 export async function getProjects(): Promise<Project[] | undefined> {
   const response = await fetch(process.env.API_URL + "/project/list", {
     method: "GET",
-    cache: "no-store",
   });
 
   if (!response.ok) {
@@ -151,6 +150,8 @@ export async function deleteProject(id: string): Promise<boolean> {
     return false;
   }
 
+  revalidatePath("/dashboard/manage");
+  revalidatePath("/showcase");
   return true;
 }
 
@@ -221,6 +222,7 @@ export async function updateProject(
   }
 
   revalidatePath("/dashboard/manage");
+  revalidatePath("/showcase");
   return true;
 }
 
@@ -296,6 +298,7 @@ export async function addProject(
   }
 
   revalidatePath("/dashboard/manage");
+  revalidatePath("/showcase");
   return true;
 }
 

--- a/components/client/dashboard/add.tsx
+++ b/components/client/dashboard/add.tsx
@@ -151,7 +151,6 @@ export default function AddProjectForm() {
             name="projectUrl"
             type="url"
             className="col-span-3"
-            required
           />
         </div>
         {creators.map((creator, index) => (

--- a/components/ui/showcase-item.tsx
+++ b/components/ui/showcase-item.tsx
@@ -120,34 +120,34 @@ export default function ShowcaseItem({ items }: { items: Project }) {
                   </Button>
                 </DialogClose>
                 {items.projectUrl !== "" && (
-                <Button asChild>
-                  <Link
-                    href={items.projectUrl}
-                    className="flex items-center"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <span>View</span>
-                    <ExternalLinkIcon />
-                  </Link>
-                </Button>
+                  <Button asChild>
+                    <Link
+                      href={items.projectUrl}
+                      className="flex items-center"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <span>View</span>
+                      <ExternalLinkIcon />
+                    </Link>
+                  </Button>
                 )}
               </DialogFooter>
             </DialogContent>
           </Dialog>
 
           {items.projectUrl !== "" && (
-          <Button asChild className="w-full">
-            <Link
-              href={items.projectUrl}
-              className="flex items-center"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span>View</span>
-              <ExternalLinkIcon />
-            </Link>
-          </Button>
+            <Button asChild className="w-full">
+              <Link
+                href={items.projectUrl}
+                className="flex items-center"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span>View</span>
+                <ExternalLinkIcon />
+              </Link>
+            </Button>
           )}
         </CardFooter>
       </Card>


### PR DESCRIPTION
Remove 'no-store' options when fetching projects to perform a cache store, and added `revalidatePath` function for '/dashboard/manage' and '/showcase' to revalidate cache when doing actions on projects

Make project link input in add project optional